### PR TITLE
Remove PR cleanup from build pipeline

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -115,11 +115,6 @@ node {
         }
       }
     }
-    if (mergedPrNo != '') {
-      stage('Remove merged PR') {
-        defraUtils.undeployChart(KUBE_CREDENTIALS_ID, serviceName, mergedPrNo)
-      }
-    }
     stage('Set GitHub status as success') {
       defraUtils.setGithubStatusSuccess()
     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ffc-elm-apply",
   "description": "Environmental Land Management application",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "homepage": "https://github.com/DEFRA/ffc-elm-apply",
   "repository": {
     "type": "git",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/ELM-1638

PR resource cleanup has moved to a separate pipeline, triggered
automatically on merge via Jenkins action triggers (configured in the
Jenkins UI).